### PR TITLE
CON-1086: Publish to new public Artifactory, add regular expression to include RC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,8 +113,11 @@ static Map<String, String> getEnvironmentVariables(String... envNames) {
 }
 
 String getArtifactoryForPublication() {
-    def repositoryName = conclave_graal_version.endsWith("-SNAPSHOT") ? "conclave-maven-dev" : "conclave-maven-release"
-    return "https://software.r3.com/artifactory/" + repositoryName
+    def mavenDevRepositoryPath = 'conclave-maven-dev'
+    def mavenReleaseRepositoryPath = 'conclave-maven-release'
+    def useDevRepository = conclave_graal_version.endsWith("-SNAPSHOT") || conclave_graal_version.matches(/.+\-RC[0-9]+$/)
+    def repositoryPath = useDevRepository ? mavenDevRepositoryPath : mavenReleaseRepositoryPath
+    return "https://software.r3.com/artifactory/" + repositoryPath
 }
 
 // Writes the current date and time to a file


### PR DESCRIPTION
As we are using the new public Artifactory, we want that RC artifacts are also published to `conclave-maven-dev` and not `conclave-maven-release`.